### PR TITLE
Fix bug with command lengths over 127

### DIFF
--- a/CLI/CLIServer.cpp
+++ b/CLI/CLIServer.cpp
@@ -202,7 +202,7 @@ void Parser::cliServer()
 						close(i);
 						continue; // go to next socket
 					}
-					if (len < (int) sizeof(len)) // should never get here
+					if (nread < (int) sizeof(len)) // should never get here
 					{
 						char buf[BUFSIZ];
 						sprintf(buf, "Unable to read complete length, s.b. %d bytes, got %d bytes\n", sizeof(len), len);


### PR DESCRIPTION
The wrong value is being compared for the length.

It was working before because len was a large number (above 4) so never failed the check.

Command line lengths in the range 128-255 have the high bit set in the least significant byte (which is the most significant byte before the ntohl byte reversal is done). During the comparison that first bit is interpreted as a sign bit, so len is interpreted as negative and the check incorrectly fails.
