### PR TITLE
Add support for Ettus subdevices.

### DIFF
--- a/Transceiver52M/UHDDevice.cpp
+++ b/Transceiver52M/UHDDevice.cpp
@@ -218,7 +218,7 @@ public:
 	uhd_device(int sps, bool skip_rx);
 	~uhd_device();
 
-	int open(const std::string &args, bool extref);
+	int open(const std::string &args, bool extref, const std::string &subdev);
 	bool start();
 	bool stop();
 	void restart(uhd::time_spec_t ts);
@@ -530,7 +530,7 @@ bool uhd_device::parse_dev_type()
 	return true;
 }
 
-int uhd_device::open(const std::string &args, bool extref)
+int uhd_device::open(const std::string &args, bool extref, const std::string &subdev)
 {
 	// Find UHD devices
 	uhd::device_addr_t addr(args);
@@ -555,7 +555,13 @@ int uhd_device::open(const std::string &args, bool extref)
 
 	if (extref)
 		set_ref_clk(true);
-
+	
+	//specify subdevice (daughterboard)
+	if(!subdev.empty()) {
+		usrp_dev->set_tx_subdev_spec(subdev);
+		usrp_dev->set_rx_subdev_spec(subdev);
+	}
+	
 	// Create TX and RX streamers
 	uhd::stream_args_t stream_args("sc16");
 	tx_stream = usrp_dev->get_tx_stream(stream_args);

--- a/Transceiver52M/radioDevice.h
+++ b/Transceiver52M/radioDevice.h
@@ -39,7 +39,7 @@ class RadioDevice {
   static RadioDevice *make(int sps, bool skipRx = false);
 
   /** Initialize the USRP */
-  virtual int open(const std::string &args = "", bool extref = false)=0;
+  virtual int open(const std::string &args = "", bool extref = false, const std::string &subdev = "")=0;
 
   /** Start the USRP */
   virtual bool start()=0;

--- a/Transceiver52M/runTransceiver.cpp
+++ b/Transceiver52M/runTransceiver.cpp
@@ -112,7 +112,7 @@ int testConfig(const char *filename)
 int main(int argc, char *argv[])
 {
   int trxPort, radioType, extref = 0, fail = 0;
-  std::string deviceArgs, logLevel, trxAddr;
+  std::string deviceArgs, logLevel, trxAddr, subdev;
   RadioDevice *usrp = NULL;
   RadioInterface *radio = NULL;
   Transceiver *trx = NULL;
@@ -141,6 +141,7 @@ int main(int argc, char *argv[])
   logLevel = gConfig.getStr("Log.Level");
   trxPort = gConfig.getNum("TRX.Port");
   trxAddr = gConfig.getStr("TRX.IP");
+  subdev = gConfig.getStr("TRX.Subdevice");
 
   if (gConfig.defines("TRX.Reference"))
     extref = gConfig.getNum("TRX.Reference");
@@ -155,7 +156,7 @@ int main(int argc, char *argv[])
   srandom(time(NULL));
 
   usrp = RadioDevice::make(SPS);
-  radioType = usrp->open(deviceArgs, extref);
+  radioType = usrp->open(deviceArgs, extref, subdev);
   if (radioType < 0) {
     LOG(ALERT) << "Transceiver exiting..." << std::endl;
     return EXIT_FAILURE;

--- a/apps/GetConfigurationKeys.cpp
+++ b/apps/GetConfigurationKeys.cpp
@@ -3077,6 +3077,17 @@ ConfigurationKeyMap getConfigurationKeys()
 	);
 	map[tmp.getName()] = tmp;
 	}
+	
+	{ ConfigurationKey tmp("TRX.Subdevice","",
+		"",
+		ConfigurationKey::CUSTOMERWARN,
+		ConfigurationKey::STRING,
+		"",
+		true,
+		"This value is a string that specifies a subdevice for Ettus Hardware."
+	);
+	map[tmp.getName()] = tmp;
+	}
 
 	{ ConfigurationKey tmp("TRX.Timeout.Clock","10",
 		"seconds",

--- a/apps/OpenBTS.example.sql
+++ b/apps/OpenBTS.example.sql
@@ -234,6 +234,7 @@ INSERT OR IGNORE INTO "CONFIG" VALUES('TRX.IP','127.0.0.1',1,0,'IP address of th
 INSERT OR IGNORE INTO "CONFIG" VALUES('TRX.MinimumRxRSSI','-63',0,0,'Bursts received at the physical layer below this threshold are automatically ignored.  Values in dB.  Set at the factory.  Do not adjust without proper calibration.');
 INSERT OR IGNORE INTO "CONFIG" VALUES('TRX.Port','5700',1,0,'IP port of the transceiver application.  Static.');
 INSERT OR IGNORE INTO "CONFIG" VALUES('TRX.RadioFrequencyOffset','128',1,0,'Fine-tuning adjustment for the Transceiver master clock.  Roughly 170 Hz/step.  Set at the factory.  Do not adjust without proper calibration.  Static.');
+INSERT OR IGNORE INTO "CONFIG" VALUES('TRX.Subdevice','',1,0,'Subdevice (Daughterboard) to use on Ettus hardware that supports it');
 INSERT OR IGNORE INTO "CONFIG" VALUES('TRX.Timeout.Clock','10',0,0,'How long to wait during a read operation from the Transceiver before giving up.');
 INSERT OR IGNORE INTO "CONFIG" VALUES('TRX.Timeout.Start','2',0,0,'How long to wait during system startup before checking to see if the Transceiver can be reached.');
 INSERT OR IGNORE INTO "CONFIG" VALUES('TRX.TxAttenOffset','0',1,0,'Hardware-specific gain adjustment for transmitter, matched to the power amplifier, expessed as an attenuation in dB.  Set at the factory.  Do not adjust without proper calibration.  Static.');


### PR DESCRIPTION
This allows a user to configure which subdevice (daughterboard) of an Ettus the OpenBTS transceiver uses via the 'TRX.Subdevice' config entry.  If the configuration value is left empty (default), the transceiver will open the UHD device the same way it did previously (defaulting to daughterboard A). This behavior would cause OpenBTS to crash when the desired ARFCN was outside of daughterboard A's frequency range. Tested on an X310, but should work on any other multi-slot Ettus products.