### PR TITLE
Crimson: Add support for Crimson TRX

### DIFF
--- a/Transceiver52M/radioDevice.h
+++ b/Transceiver52M/radioDevice.h
@@ -34,7 +34,7 @@ class RadioDevice {
   enum TxWindowType { TX_WINDOW_USRP1, TX_WINDOW_FIXED };
 
   /* Radio interface types */
-  enum RadioInterfaceType { NORMAL, RESAMP_64M, RESAMP_100M };
+  enum RadioInterfaceType { NORMAL, RESAMP_64M, RESAMP_100M, RESAMP_100M_NO_RXOFF };
 
   static RadioDevice *make(int sps, bool skipRx = false);
 

--- a/Transceiver52M/runTransceiver.cpp
+++ b/Transceiver52M/runTransceiver.cpp
@@ -169,6 +169,10 @@ int main(int argc, char *argv[])
   case RadioDevice::RESAMP_100M:
     radio = new RadioInterfaceResamp(usrp, 3, SPS, false);
     break;
+  case RadioDevice::RESAMP_100M_NO_RXOFF:
+    radio = new RadioInterfaceResamp(usrp, 0, SPS, false);
+    radioType = RadioDevice::RESAMP_100M;   // reset radioType for radio->init() call
+    break;
   default:
     LOG(ALERT) << "Unsupported configuration";
     fail = 1;


### PR DESCRIPTION
Added a new device under the list of UHD devices. Added timing parameters (delay). Was required to add a new enumeration to the radio type due to a hard-coding of 3 rx slots of delays. Crimson requires 0 rx slots of delay.
