### PR TITLE
Update sigProcLib.cpp

### DIFF
--- a/Transceiver52M/sigProcLib.cpp
+++ b/Transceiver52M/sigProcLib.cpp
@@ -24,8 +24,7 @@
 
 #include "sigProcLib.h"
 #include "GSMCommon.h"
-#include "sendLPF_961.h"
-#include "rcvLPF_651.h"
+
 
 extern "C" {
 #include "convolve.h"


### PR DESCRIPTION
These two includes cause the build script to throw an error. Maybe these files are getting referenced in another location also.